### PR TITLE
remove superassignment 

### DIFF
--- a/R/compare_genelist.R
+++ b/R/compare_genelist.R
@@ -234,8 +234,8 @@ compare_lists <- function(bin_mat,
             bin_temp <- bin_temp[order(bin_temp, decreasing = TRUE)]
             list_top <- names(bin_temp)
             v2 <- list_top[list_top %in% v1]
-            v1 <<- v1
-            v2 <<- v2
+            v1 <- v1
+            v2 <- v2
             sum(sapply(seq_along(v1), function(i) abs(i - (which(v2 == v1[i])))))
           }
         )

--- a/R/plot.R
+++ b/R/plot.R
@@ -384,7 +384,7 @@ plot_best_call <- function(cor_matrix,
     threshold = threshold
   )
 
-  df_temp_full <<- call_to_metadata(
+  df_temp_full <- call_to_metadata(
     df_temp,
     metadata = metadata,
     cluster_col = cluster_col,


### PR DESCRIPTION
``` r
library(clustifyr)

res <- clustify(
  input = pbmc_matrix_small,
  metadata = pbmc_meta,
  ref_mat = pbmc_bulk_matrix,
  query_genes = pbmc_vargenes,
  cluster_col = "classified"
)

plts <- plot_best_call(
  cor_matrix = res,
  metadata = pbmc_meta,
  cluster_col = "classified"
)

# shouldn't be in user environment
df_temp_full
#>                orig.ident nCount_RNA nFeature_RNA percent.mt
#> AAACATACAACCAC     pbmc3k       2419          779  3.0177759
#> AAACATTGAGCTAC     pbmc3k       4903         1352  3.7935958
#> AAACATTGATCAGC     pbmc3k       3147         1129  0.8897363
#> AAACCGTGCTTCCG     pbmc3k       2639          960  1.7430845
#> AAACCGTGTATGCG     pbmc3k        980          521  1.2244898
#> AAACGCACTGGTAC     pbmc3k       2163          781  1.6643551
#> AAACGCTGACCAGT     pbmc3k       2175          782  3.8160920
```

<sup>Created on 2019-09-12 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>